### PR TITLE
Adjust the Android ARM cross-compiler options

### DIFF
--- a/fpcupdeluxemainform.pas
+++ b/fpcupdeluxemainform.pas
@@ -942,6 +942,24 @@ begin
         FPCupManager.CrossOPT:='-CpARMV7 ';
       end
       else
+      if (FPCupManager.CrossOS_Target='android') then
+      begin
+        // Use hard floats, using armeabi-v7a Android ABI.
+        //
+        // Note: do not use -CaEABIHF on Android, to not use
+        // armeabi-v7a-hard ABI. Reasons:
+        // - armeabi-v7a-hard ABI is not adviced anymore by Google,
+        //   see "ARM Hard Float ABI Removal" on
+        //   https://android.googlesource.com/platform/ndk/+/353e653824b79c43b948429870d0abeedebde386/docs/HardFloatAbi.md
+        //   (as far as I understand, armeabi-v7a-hard corresponds to
+        //   FPC -CaEABIHF ).
+        // - it prevents calling functions from libraries not using
+        //   armeabi-v7a-hard ABI (but only using armeabi-v7a) like
+        //   http://repo.or.cz/openal-soft/android.git or
+        //   https://github.com/michaliskambi/tremolo-android .
+        FPCupManager.CrossOPT:='-CpARMV7A -CfVFPV3 ';
+      end
+      else
       begin
         // default: armhf
         FPCupManager.FPCOPT:='-dFPC_ARMHF ';


### PR DESCRIPTION
This adjusts cross-compilations options for Android/ARM to what is present in settings.ini for `[android]` and what is suggested on http://wiki.freepascal.org/Android .

1. Most notably, the Android cross-compiler will no longer use -CaEABIHF by default.

    The -CaEABIHF makes the generated code crash when it tries to communicate with external libraries targetting armeabi-v7a, like OpenAL (from http://repo.or.cz/openal-soft/android.git ) or Tremolo (from https://github.com/michaliskambi/tremolo-android ). In particular, applications using Castle Game Engine crash as soon as they try to play a sound (at which point Pascal code calls alSourcef which is an OpenAL function taking a float, which is passed differently with and without -CaEABIHF/armeabi-v7a-hard (as far as I understand)).

    The external libraries would have to be compiled with armeabi-v7a-hard as far as I know, and this is generally not used and Google is phasing out the "ARM Hard Float ABI". See https://android.googlesource.com/platform/ndk/+/353e653824b79c43b948429870d0abeedebde386/docs/HardFloatAbi.md for more information.

    Note that I'm not an Android or ARM expert... However, I did confirm all this with testing various FPC compilations options and Castle Game Engine (which uses external libraries for OggVorbis and sound on Android).

    The fact that the settings.ini file generated by fpcupdeluxe contains the proper compilation options:

    ~~~~
    fpcopt=""
    crossopt="-CpARMV7 -CfVFPV3"
    ~~~~

    ... also confirms my findings. I gues that fpcupdeluxemainform.pas was simply not adjusted to Android/ARM, to follow the same defaults as settings.ini?

2. This change also avoids having -OoFASTMATH when compiling RTL for Android/ARM. The -OoFASTMATH is extremely drastic in my experience, it makes most Castle Game Engine calculations too unprecise to use.

3. This change also avoids having -dFPC_ARMHF, which *it seems* does nothing more. It's also not present in settings.ini for [android], or http://wiki.freepascal.org/Android .
