### PR TITLE
Add baregame Lazarus packages

### DIFF
--- a/fpcup.ini
+++ b/fpcup.ini
@@ -1095,6 +1095,11 @@ Installdir=$(fpcdir)/../ccr/$(name)
 Enabled=0
 GitURL=https://github.com/sysrpl/Bare.Game
 ArchiveURL=https://github.com/sysrpl/Bare.Game/archive/master.zip
+; Install:
+InstallExecute=$(lazarusdir)/lazbuild --primary-config-path=$(LazarusPrimaryConfigPath) $(Installdir)/source/barerun.lpk
+; Design time:
+; (This fails to compile now, see https://github.com/sysrpl/Bare.Game/pull/5 )
+;AddPackage=$(Installdir)/tools/design/baredsgn.lpk
 UnInstall=rm -Rf $(Installdir)
 
 [FPCUPModule93]


### PR DESCRIPTION
Register the barerun.lpk and baredsgn.lpk packages of BareGame.

(The design-time baredsgn.lpk is commented out for now, since it fails to compile. Once  https://github.com/sysrpl/Bare.Game/pull/5 is applied, it will compile again.)