### PR TITLE
Fix compilation with FPC 3.0.2 that does not have FUnZipper.UseUTF8

### DIFF
--- a/fpcuputil.pas
+++ b/fpcuputil.pas
@@ -1301,9 +1301,14 @@ begin
     begin
       for x:=0 to FUnZipper.Entries.Count-1 do
       begin
+        { UTF8 features are only available in FPC >= 3.1 }
+        {$IF FPC_FULLVERSION > 30100}
         if FUnZipper.UseUTF8
           then s:=FUnZipper.Entries.Entries[x].UTF8ArchiveFileName
-          else s:=FUnZipper.Entries.Entries[x].ArchiveFileName;
+          else
+        {$endif}
+          s:=FUnZipper.Entries.Entries[x].ArchiveFileName;
+
         if (Pos('/.',s)>0) OR (Pos('\.',s)>0) then continue;
         if (Length(s)>0) AND (s[1]='.') then continue;
         FFileList.Append(s);


### PR DESCRIPTION
The UTF8 features of UnZipper are not present in FPC 3.0.2 yet.
They were committed at this moment:
https://github.com/graemeg/freepascal/commit/85105d844948baa13b3f788b310e084616bea256
The FPC 3.0.2 sources do not contain these changes.