### PR TITLE
Fix GetCrossBuildOptions to understand the "win32" / "win64" names

### DIFF
--- a/extrasettings.pas
+++ b/extrasettings.pas
@@ -505,13 +505,16 @@ var
   xCPU:TCPU;
   xOS:TOS;
 begin
-  try
-    xCPU:=TCPU(GetEnumValue(TypeInfo(TCPU),aCPU));
-    xOS:=TOS(GetEnumValue(TypeInfo(TOS),aOS));
-    result:=FCrossUtils[xCPU,xOS].CrossBuildOptions;
-  except
-    result:='';
-  end;
+  if aOS='win32' then aOS:='windows';
+  if aOS='win64' then aOS:='windows';
+
+  xCPU:=TCPU(GetEnumValue(TypeInfo(TCPU),aCPU));
+  if Ord(xCPU) < 0 then
+    raise Exception.CreateFmt('Invalid CPU name "%s" for GetCrossBuildOptions', [aCPU]);
+  xOS:=TOS(GetEnumValue(TypeInfo(TOS),aOS));
+  if Ord(xOS) < 0 then
+    raise Exception.CreateFmt('Invalid OS name "%s" for GetCrossBuildOptions', [aOS]);
+  result:=FCrossUtils[xCPU,xOS].CrossBuildOptions;
 end;
 
 

--- a/fpcupdeluxe.lps
+++ b/fpcupdeluxe.lps
@@ -3,7 +3,7 @@
   <ProjectSession>
     <PathDelim Value="\"/>
     <Version Value="10"/>
-    <BuildModes Active="win32"/>
+    <BuildModes Active="Default"/>
     <Units Count="305">
       <Unit0>
         <Filename Value="fpcupdeluxe.lpr"/>


### PR DESCRIPTION
As I was testing #13, I noticed that it does not work if I try to customize cross-compiler options for win32.

1. The first step was to notice that GetCrossBuildOptions silences every exception type, with:

  ~~~~
  try
    ...
  except
    result := '';
  end;
  ~~~~

2. After removing this try/except, I saw that the line `result:=FCrossUtils[xCPU,xOS].CrossBuildOptions;` inside `GetCrossBuildOptions` was causing an Access Violation (SEGFAULT). Investigating, it turns out that it was given OS name as "win32", but it expected "windows".

    - First, I fixed the code to make a clear exception in this case, so user will see:
      """Invalid OS name "win32" for GetCrossBuildOptions."""
      This should allow to notice these errors:)

    - Second, I added at the beginning of GetCrossBuildOptions a code to rename OS to match the enum variable names. I see that TForm1.ButtonAutoUpdateCrossCompiler is doing similar replacements, but in the other way.

As a suggestion:

It would be simpler to remove these renames, both from TForm1.ButtonAutoUpdateCrossCompiler and from GetCrossBuildOptions, and use, consistently, the same names for CPU/OS everywhere.

- It would force to define all necessary OSes and CPUs in the enum types. Right now, I think that TOS enum is missing the iPhoneSimulator OS.

- It would force calling the OSes in the same way everywhere, which I think is good for consistency. (BTW, I prefer "iPhoneSim" over "i-sim", as "iPhoneSim" is a more familiar name.)

- The "windows" enum would need to be split into two OSes "win32" and "win64" for this. Alternatively, everything else may be changed to use only a single "windows" value, and it is only split into win32/win64 when calling the FPC (I know that FPC command-line requires "win32" or "win64", not just "windows".)

This could make fpcupdeluxe code a bit simpler -- no more wondering whether OS/CPU needs renaming or not.

But I'll leave this decision up to you:) It's easy for me to throw some ideas, they are most probably not so easy to implement. Ignore my suggestion if it doesn't seem useful:)

P.S. As an unrelated fix, you have left the "Build Mode" in Lazarus "Project Options -> Compiler Options" as "win32".

This means that the project "wants to" be compiled for win32, even if I open it on Linux. Which of course requires a cross-compiler (Lazarus warns "Compiler .... does not support target i386-win32" if missing), and is also a little unexpected for a developer :)

I changed the "Build Mode" to "Default".

As a suggestion: you can remove the fpcupdeluxe.lps file from the GIT repository, and add it to .gitignore file. This file usually *should not* be present in the repository at all, and it would avoid these kinds of errors. That is the reason why (since some time) every Lazarus project has two files: xxx.lps (session info) and xxx.lpi (general project info). In short, you usually want to commit xxx.lpi, but not xxx.lps. Every developer should have it's own, private, version of xxx.lps. It will be auto-created if missing.