### PR TITLE
default to "Monospace" for console font, ini option to configure this

### DIFF
--- a/fpcupdeluxemainform.lfm
+++ b/fpcupdeluxemainform.lfm
@@ -107,10 +107,10 @@ object Form1: TForm1
     Color = clBlack
     Font.CharSet = ANSI_CHARSET
     Font.Color = clLime
-    Font.Height = -11
-    Font.Name = 'Courier New'
+    Font.Height = -13
+    Font.Name = 'Monospace'
     Font.Pitch = fpFixed
-    Font.Quality = fqDraft
+    Font.Quality = fqCleartype
     ParentColor = False
     ParentFont = False
     TabOrder = 5

--- a/fpcupdeluxemainform.pas
+++ b/fpcupdeluxemainform.pas
@@ -244,6 +244,8 @@ type
     procedure InitFPCupManager;
     function  GetCmdFontSize:integer;
     procedure SetCmdFontSize(aValue:integer);
+    function GetCmdFontName: String;
+    procedure SetCmdFontName(aValue: String);
     procedure ParseRevisions(IniDirectory:string);
     {$ifndef usealternateui}
     property  FPCTarget:string read FFPCTarget write SetFPCTarget;
@@ -257,7 +259,8 @@ type
     {$endif}
 
   published
-    property CmdFontSize: integer read GetCmdFontSize write SetCmdFontSize;
+    property CmdFontSize: Integer read GetCmdFontSize write SetCmdFontSize;
+    property CmdFontName: String read GetCmdFontName write SetCmdFontName;
   end;
 
 resourcestring
@@ -1816,7 +1819,7 @@ end;
 
 procedure TForm1.IniPropStorageAppRestoringProperties(Sender: TObject);
 begin
-  SessionProperties := 'WindowState;Width;Height;Top;Left;CmdFontSize;';
+  SessionProperties := 'WindowState;Width;Height;Top;Left;CmdFontSize;CmdFontName;';
   //Width := MulDiv(Width, 96, Screen.PixelsPerInch);
   //Height := MulDiv(Height, 96, Screen.PixelsPerInch);
 end;
@@ -1824,9 +1827,9 @@ end;
 procedure TForm1.IniPropStorageAppSavingProperties(Sender: TObject);
 begin
   if Self.WindowState=wsMaximized then
-    SessionProperties := 'WindowState;CmdFontSize;'
+    SessionProperties := 'WindowState;CmdFontSize;CmdFontName;'
   else
-    SessionProperties := 'WindowState;Width;Height;Top;Left;CmdFontSize;';
+    SessionProperties := 'WindowState;Width;Height;Top;Left;CmdFontSize;CmdFontName;';
 end;
 
 procedure TForm1.ListBoxTargetDrawItem(Control: TWinControl; Index: Integer;
@@ -5048,6 +5051,16 @@ end;
 procedure TForm1.SetCmdFontSize(aValue:integer);
 begin
   CommandOutputScreen.Font.Size:=aValue;
+end;
+
+function TForm1.GetCmdFontName: String;
+begin
+  Result := CommandOutputScreen.Font.Name;
+end;
+
+procedure TForm1.SetCmdFontName(aValue: String);
+begin
+  CommandOutputScreen.Font.Name:=aValue;
 end;
 
 procedure TForm1.FillSourceListboxes;


### PR DESCRIPTION
The alias "Monospace" will default to Courier New on Windows and to a nice readable monospaced font on *ix systems.

The font in the log window is looking exceptionally ugly on Linux systems because by default it is trying to use "Courier New". Of all existing fonts this is by far the worst choice for anything console related. I have changed the default to use the alias "Monospace" which will result in a nice readable monospaced font on all tested systems. On Windows the "Monospace" alias will still default to "Courier New" (at least on a fresh Windows 7 install) and therefore will remain exactly as ugly as before, but at least the Windows users can now configure it in the ini.

Additionally I have added this field to the PropStorage so it will appear as config option `CmdFontName` in the ini file, right next to the already existing `CmdFontSize`.