### PR TITLE
Fix hardcoded build platform info in startup log.

### DIFF
--- a/sources/fpcuputil.pas
+++ b/sources/fpcuputil.pas
@@ -379,6 +379,7 @@ function GetSourceOS:string;
 function GetSourceCPUOS:string;
 function GetFPCBuildVersion:string;
 function GetDistro(const aID:string=''):string;
+function GetBuildPlatform:string;
 function GetFreeBSDVersion:byte;
 function checkGithubRelease(const aURL:string):string;
 {$IF DEFINED(FPC_FULLVERSION) AND (FPC_FULLVERSION < 30200)}
@@ -4595,6 +4596,42 @@ begin
        then t:=t+'-'+InttoStr(Major)+'.'+InttoStr(Minor)+'.'+InttoStr(Build);
   {$endif MSWindows}
   result:=t;
+end;
+
+function GetBuildPlatform:string;
+var
+  Major,Minor,Build,Patch: Integer;
+  s: string;
+begin
+  {$ifdef MSWindows}
+    if GetWin32Version(Major,Minor,Build) then
+    begin
+      if (Major=10) and (Build>=22000) then result:='Win11'
+      else if Major=10 then result:='Win10'
+      else if (Major=6) and (Minor=3) then result:='Win8.1'
+      else if (Major=6) and (Minor=2) then result:='Win8'
+      else if (Major=6) and (Minor=1) then result:='Win7'
+      else result:='Win'+InttoStr(Major)+'.'+InttoStr(Minor);
+    end
+    else result:='Win';
+    if IsWindows64
+       then result:=result+' x86_64'
+       else result:=result+' i386';
+  {$else}
+    {$ifdef Darwin}
+      if RunCommand('sw_vers',['-productName'], s) and (Length(s)>0)
+         then result:=Trim(s)
+         else result:=GetSourceOS;
+      if RunCommand('sw_vers',['-productVersion'], s) and (Length(s)>0) then
+      begin
+        VersionFromString(s,Major,Minor,Build,Patch);
+        result:=result+' '+InttoStr(Major)+'.'+InttoStr(Minor);
+      end;
+    {$else}
+      result:=GetDistro;
+    {$endif Darwin}
+    result:=result+' '+GetSourceCPU;
+  {$endif MSWindows}
 end;
 
 function GetFreeBSDVersion:byte;

--- a/sources/fpcuputil.pas
+++ b/sources/fpcuputil.pas
@@ -4625,7 +4625,16 @@ begin
       if RunCommand('sw_vers',['-productVersion'], s) and (Length(s)>0) then
       begin
         VersionFromString(s,Major,Minor,Build,Patch);
-        result:=result+' '+InttoStr(Major)+'.'+InttoStr(Minor);
+        case Major of
+          26: result:='macOS Tahoe ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+          15: result:='macOS Sequoia ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+          14: result:='macOS Sonoma ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+          13: result:='macOS Ventura ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+          12: result:='macOS Monterey ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+          11: result:='macOS Big Sur ('+InttoStr(Major)+'.'+InttoStr(Minor)+')';
+        else
+          result:=result+' '+InttoStr(Major)+'.'+InttoStr(Minor);
+        end;
       end;
     {$else}
       result:=GetDistro;

--- a/sources/updeluxe/fpcupdeluxemainform.pas
+++ b/sources/updeluxe/fpcupdeluxemainform.pas
@@ -4493,7 +4493,7 @@ begin
 
   AddMessage(DateTimeToStr(now)+': '+BeginSnippet+' V'+RevisionStr+' ('+VersionDate+') started.');
   AddMessage('FPCUPdeluxe V'+DELUXEVERSION+' for '+GetSourceCPUOS+' running on '+GetDistro);
-  AddMessage('Built with: FPC '+GetFPCBuildVersion + ' on Win11 x86_64');
+  AddMessage('Built with: FPC '+GetFPCBuildVersion + ' on '+GetBuildPlatform);
   AddMessage('');
 
   if SettingsForm.SaveScript then FPCupManager.SaveSettings;
@@ -4738,7 +4738,7 @@ begin
   AddMessage(Self.Caption);
   {$ifndef NetBSD}
   AddMessage('Running on '+GetDistro);
-  AddMessage('Built with: FPC '+GetFPCBuildVersion + ' on Win11 x86_64');
+  AddMessage('Built with: FPC '+GetFPCBuildVersion + ' on '+GetBuildPlatform);
   {$ifdef FreeBSD}
   AddMessage('Detected mayor FreeBSD version '+InttoStr(GetFreeBSDVersion));
   {$endif FreeBSD}


### PR DESCRIPTION
The startup log always showed Built with: FPC 3.x.x on Win11 x86_64, regardless of the actual build platform

EDIT: Ooops. Even though the idea is good, this is a completely wrong implementation. This will just show the runtime environment, which is already shown. I need to find a proper way to do it before creating a new PR.